### PR TITLE
ENGDESK-3493: Fix validation of nested GET parameters

### DIFF
--- a/spec/validate.go
+++ b/spec/validate.go
@@ -1,7 +1,7 @@
 package spec
 
 import (
-	"github.com/lestrrat/go-jsschema"
+	schema "github.com/lestrrat/go-jsschema"
 	"github.com/lestrrat/go-jsval"
 	"github.com/lestrrat/go-jsval/builder"
 )


### PR DESCRIPTION
Fixes #7

There's two different ways one can specify GET filters in the openapi
schema:

1:

```
    "/available_phone_numbers": {
      "get": {
        "summary": "List available phone numbers",
        "operationId": "listAvailablePhoneNumbers",
        "tags": [
          "Number Search"
        ],
        "parameters": [
          {
            "name": "filter[phone_number][starts_with]",
            "in": "query",
            "description": "Filter numbers starting with a pattern",
            "schema": {
              "type": "string"
            },
            "examples": {
              "generic": {
                "value": "FOO",
                "summary": "Find numbers starting with the prefix 'FREE'"
              }
            }
          },
```

2:

```
    "/available_phone_numbers": {
      "get": {
        "summary": "List available phone numbers",
        "operationId": "listAvailablePhoneNumbers",
        "tags": [
          "Number Search"
        ],
        "parameters": [
          {
            "name": "filter",
            "in": "query",
            "schema": {
              "type": "object",
              "properties": {
                "phone_number": {
                  "type": "object",
                  "properties": {
                    "contains": {
                      "type": "string"
                    },
                    "ends_with": {
                      "type": "string"
                    },
                    "starts_with": {
                      "type": "string"
                    }
                  }
                },
```

The difference being a flat listing of filter properties vs a nested schema
of properties.

This causes a problem with `telnyx-mock` as the HTTP server does some work
to unroll the GET parameters into a nested `map` structure. See
`./param/nestedtypeassembler/nestedtypeassembler.go`>

If the openapi spec uses the flat property structure and we try to pass in
the nested `map`, built by `nestedtypeassembler`, we get validation errors
from `go-jsval` as it fails to compare the two inputs.

This commit introduces a check to keep track of nested vs flat openapi
specs and ensures `go-jsval` is properly passed either the nested GET
parameters or we flatten them.