### PR TITLE
Return first branch of oneof

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -312,6 +312,20 @@ func (g *DataGenerator) generateInternal(params *GenerateParams) (interface{}, e
 		})
 	}
 
+    if len(schema.OneOf) > 0 {
+        // For OneOf, we always return the fist branch
+        return g.generateInternal(&GenerateParams{
+            Expansions:    params.Expansions,
+            PathParams:    nil,
+            RequestMethod: params.RequestMethod,
+            RequestPath:   params.RequestPath,
+
+            schema:  schema.OneOf[0],
+            context: fmt.Sprintf("%sChoosing first branch of oneOf:\n", context),
+            example: example,
+        })
+    }
+
 	if isListResource(schema) {
 		// We special-case list resources and always fill in the list with at least
 		// one item of data, regardless of what was present in the example


### PR DESCRIPTION
Sample request and response for a schema using `oneOf`:

```
$ curl -g  'http://localhost:12111/v2/detail_records?filter[record_type]=message' -H "Authorization: Bearer KEYSUPERSECRET"
{
  "data": [
    {
      "carrier": "T-Mobile USA",
      "carrier_fee": "0.003",
      "cld": "+1555123456",
      "cli": "+1555123456",
      "completed_at": "2020-07-01T00:00:00Z",
      "cost": "0.003",
      "country_code": "US",
      "created_at": "2020-07-01T00:00:00Z",
      "currency": "USD",
      "delivery_status": "success: webhook succeeded",
      "delivery_status_failover_url": "https://api.example.com/sms/telnyx/inbound",
      "delivery_status_webhook_url": "https://api.example.com/sms/telnyx/inbound",
      "direction": "outbound",
      "errors": [],
      "fteu": false,
      "mcc": "204",
      "message_type": "SMS",
      "mnc": "01",
      "on_net": true,
      "parts": 2,
      "profile_id": "30ef55db-c4a2-4c4a-9804-a68077973d07",
      "profile_name": "My Messaging Profile",
      "rate": "0.003",
      "record_type": "message_detail_record",
      "sent_at": "2020-07-01T00:00:00Z",
      "source_country_code": "US",
      "status": "delivered",
      "tags": "tag1,tag2,tag3",
      "updated_at": "2020-07-01T00:00:00Z",
      "user_id": "3ca7bd3d-7d82-4e07-9df4-009123068320",
      "uuid": "3ca7bd3d-7d82-4e07-9df4-009123068320"
    }
  ],
  "meta": null
}
```