### PR TITLE
update list of supported schema fields

### DIFF
--- a/spec/spec.go
+++ b/spec/spec.go
@@ -69,6 +69,8 @@ var supportedSchemaFields = []string{
 	"example",
 	"format",
 	"items",
+	"maxItems",
+	"minItems,
 	"maxLength",
 	"minLength",
 	"maximum",


### PR DESCRIPTION
`telnyx-mock` service currently breaks on startup

Ran a git bisect with `team-telnyx/openapi` and discovered this [pull request](https://github.com/team-telnyx/openapi-internal/pull/689) to have introduced the first "bad" commit of schema to break the `telnyx-mock` service.

Adding support for [additional schema fields](https://github.com/team-telnyx/openapi-internal/pull/689/files#diff-a222aa1e65a1a13f4f7b75f2270e7e5a981bcceca6e58ee4e413e99f79100b4cR351-R352) appears to resolve the issue.